### PR TITLE
Close #9 - add a workaround for interpolation of element with empty lists

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -1,7 +1,19 @@
+# Even though the net, subnet, and IAM resources are gated by a shared VPC
+# flags and counts, the interpolator will throw errors if element(list, index)
+# is used and the list is empty. These local variables include a dummy list
+# entry so that the interpolaror is satisfied. The values are deliberately
+# invalid so that broken logic will result in a resource creation failure.
+locals {
+  networks       = ["${coalescelist(var.networks, list("invalid"))}"]
+  subnets        = ["${coalescelist(var.subnets, list("invalid:invalid:1.1.1.1/32:invalid"))}"]
+  network_admins = ["${coalescelist(var.network_admins, list("invalid"))}"]
+  network_users  = ["${coalescelist(var.network_users, list("invalid"))}"]
+}
+
 # Create networks for the project
 resource "google_compute_network" "net" {
   count                   = "${var.shared_vpc_host_project_id != "" ? 0 : length(var.networks)}"
-  name                    = "${element(var.networks, count.index)}"
+  name                    = "${element(local.networks, count.index)}"
   project                 = "${google_project.project.project_id}"
   auto_create_subnetworks = false
 }
@@ -10,10 +22,10 @@ resource "google_compute_network" "net" {
 resource "google_compute_subnetwork" "subnet" {
   count         = "${var.shared_vpc_host_project_id != "" ? 0 : length(var.subnets)}"
   project       = "${google_project.project.project_id}"
-  name          = "${length(split(":", element(var.subnets, count.index))) > 3 ? element(split(":", element(var.subnets, count.index)), 3) : format("%s-%s", element(split(":", element(var.subnets, count.index)), 0), element(split(":", element(var.subnets, count.index)), 0))}"
-  ip_cidr_range = "${element(split(":", element(var.subnets, count.index)), 2)}"
-  region        = "${element(split(":", element(var.subnets, count.index)), 1)}"
-  network       = "${element(split(":", element(var.subnets, count.index)), 0)}"
+  name          = "${length(split(":", element(local.subnets, count.index))) > 3 ? element(split(":", element(local.subnets, count.index)), 3) : format("%s-%s", element(split(":", element(local.subnets, count.index)), 0), element(split(":", element(local.subnets, count.index)), 0))}"
+  ip_cidr_range = "${element(split(":", element(local.subnets, count.index)), 2)}"
+  region        = "${element(split(":", element(local.subnets, count.index)), 1)}"
+  network       = "${element(split(":", element(local.subnets, count.index)), 0)}"
 
   depends_on = ["google_compute_network.net"]
 }
@@ -23,7 +35,7 @@ resource "google_project_iam_member" "network-admins" {
   count   = "${var.is_shared_vpc_host ? length(var.network_admins) : 0}"
   project = "${google_project.project.project_id}"
   role    = "roles/compute.networkAdmin"
-  member  = "${element(var.network_admins, count.index)}"
+  member  = "${element(local.network_admins, count.index)}"
 }
 
 # If this is a shared VPC service, add the networkUser accounts to network.
@@ -31,5 +43,5 @@ resource "google_project_iam_member" "network-users" {
   count   = "${var.shared_vpc_host_project_id != "" ? length(var.network_users) : 0}"
   project = "${var.shared_vpc_host_project_id}"
   role    = "roles/compute.networkUser"
-  member  = "${element(var.network_users, count.index)}"
+  member  = "${element(local.network_users, count.index)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -201,6 +201,18 @@ EOF
   default = []
 }
 
+variable "service_account_subnets_count" {
+  default = 0
+
+  description = <<EOF
+When passing a list of service account:subnets as part of a shared VPC, you must explicitly set the number of entries in the list to work around a Terraform limitation.
+
+E.g.
+service_account_subnets = ["foobar@example.com:us-west1:bar"]
+service_account_subnets_count = 1
+EOF
+}
+
 variable "iam_assignments" {
   type = "list"
 


### PR DESCRIPTION
These changes address the issues described in #9 by adding local variables to ensure an empty list has an entry. The added entry is invalid.

This also brings in the workaround for hashicorp/terraform#10857 